### PR TITLE
Fix missing implementation of onConfig() to prevent vtable error

### DIFF
--- a/src/EspUsbHost.cpp
+++ b/src/EspUsbHost.cpp
@@ -773,6 +773,10 @@ esp_err_t EspUsbHost::submitControl(const uint8_t bmRequestType, const uint8_t b
   return err;
 }
 
+void EspUsbHost::onConfig(const uint8_t bDescriptorType, const uint8_t *p) {
+    // Implementação vazia para evitar erro de vtable
+}
+
 void EspUsbHost::_onReceiveControl(usb_transfer_t *transfer) {
   _printPcapText("GET DESCRIPTOR Response HID Report", 0x0008, 0x01, 0x80, 0x02, transfer->actual_num_bytes - 8, 0x03, &transfer->data_buffer[8]);
 


### PR DESCRIPTION
Fix missing implementation of onConfig() to prevent vtable error

## Issue:
When trying to subclass `EspUsbHost`, the linker throws the following error:

undefined reference to `EspUsbHost::onConfig(unsigned char, unsigned char const*)`

## Cause:
- The function `onConfig()` is **declared in EspUsbHost.h** but **never implemented** in EspUsbHost.cpp.
- This causes an error when the class is instantiated or extended.

## Suggested Fix:
- Add an empty function implementation in `EspUsbHost.cpp`:
```cpp
void EspUsbHost::onConfig(const uint8_t bDescriptorType, const uint8_t *p) {
    // Empty implementation to avoid vtable error
}

## Expected Outcome:
- The error should be resolved, allowing the class to be extended without linker issues.
